### PR TITLE
Update focus direction  when inconsistent

### DIFF
--- a/src/Puzzle.svelte
+++ b/src/Puzzle.svelte
@@ -101,6 +101,12 @@
       onFlipDirection();
     } else {
       focusedCellIndex = index;
+      
+      if (!cells[focusedCellIndex].clueNumbers[focusedDirection]) {
+        const newDirection = focusedDirection === "across" ? "down" : "across";
+        focusedDirection = newDirection
+      }
+
       focusedCellIndexHistory = [
         index,
         ...focusedCellIndexHistory.slice(0, numberOfStatesInHistory),


### PR DESCRIPTION
Resolves #74 

When `onFocusCell` is called, `focusedCellIndex` is updated but `focusedCell` may not be.
Check if the cell has clue number, for the focus direction otherwise change the focus direction.